### PR TITLE
fix: replace statusBarOrientation with interfaceOrientation for iOS 13 and up

### DIFF
--- a/ios/Plugin/ScreenOrientation.swift
+++ b/ios/Plugin/ScreenOrientation.swift
@@ -134,7 +134,16 @@ import UIKit
         case UIInterfaceOrientation.portraitUpsideDown.rawValue:
             return "portrait-secondary"
         default:
-            let isPortrait = UIApplication.shared.statusBarOrientation.isPortrait
+            var isPortrait = false
+            if #available(iOS 13.0, *) {
+              isPortrait = UIApplication.shared.windows
+                .first?
+                .windowScene?
+                .interfaceOrientation
+                .isPortrait ?? false
+            } else {
+              isPortrait = UIApplication.shared.statusBarOrientation.isPortrait
+            }
             return isPortrait ? "portrait-primary" : "landscape-primary"
         }
     }


### PR DESCRIPTION
This PR fixes https://github.com/capawesome-team/capacitor-screen-orientation/issues/23:

- updates `convertOrientationValueToType` for iOS to use the `interfaceOrientation` of the window scene instead of `statusBarOrientation` as that is deprecated from iOS 13.0 and above.
- allows for backwards compatibility by leaving the original functionality in for <13.0

NOTE: I am not a Swift developer so please feel free to pull my solution apart!